### PR TITLE
Added jail functionality fixes#10

### DIFF
--- a/board.py
+++ b/board.py
@@ -8,6 +8,9 @@ class Board:
     Contains location data.\n
     """
     def __init__(self, num_players) -> None:
+        # owner var indicates who owns, but also is used for special codes below:
+        # Special codes: -1 is not owned, -2 is mortaged, -3 is community chest, -4 is chance, -5 is tax
+        # -6 is jail, -7 is go to jail, -8 is free parking, -9 is luxury, -10 is go 
         property = Property(num_players, "Go", -10, (32,72), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         self.locations = {
             0: Property(num_players, "Go", -10, (32,72), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
@@ -20,7 +23,7 @@ class Board:
             7: Property(0, "Chance", -4, (32,23), COLORS.CHANCE, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             8: Property(0, "Vermont Avenue", -1, (32,16), COLORS.LIGHTBLUE, 100, 50, 6, 30, 90, 270, 400, 550, 50),
             9: Property(0, "Connecticut Avenue", -1, (32,9), COLORS.LIGHTBLUE, 120, 50, 8, 40, 100, 300, 450, 600, 60),
-            10: Property(0, "Jail", -7, (32,23), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            10: Property(0, "Jail", -6, (32,2), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             11: Property(0, "St. Charles Place", -1, (29,2), COLORS.ROUGE, 140, 100, 10, 50, 150, 450, 625, 750, 70),
             12: Property(0, "Electric Company", -1, (26,2), COLORS.YELLOW, 150, 0, 0, 4, 10, 0, 0, 0, 75),
             13: Property(0, "States Avenue", -1, (23, 2), COLORS.ROUGE, 140, 100, 10, 50, 150, 450, 625, 750, 70),
@@ -30,7 +33,7 @@ class Board:
             17: Property(0, "Community Chest", -3, (11,2), COLORS.COMMUNITY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             18: Property(0, "Tennessee Avenue", -1, (8,2), COLORS.ORANGE, 180, 100, 14, 70, 200, 550, 750, 950, 90),
             19: Property(0, "New York Avenue", -1, (5,2), COLORS.ORANGE, 200, 100, 16, 80, 220, 600, 800, 1000, 100),
-            20: Property(0, "Free Parking", -1, (2,2), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            20: Property(0, "Free Parking", -8, (2,2), COLORS.LIGHTGRAY, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             21: Property(0, "Kentucky Avenue", -1, (2,9), COLORS.RED, 220, 150, 18, 90, 250, 700, 875, 1050, 110),
             22: Property(0, "Chance", -4, (2,16), COLORS.CHANCE, 0, 0, 0, 0, 0, 0, 0, 0, 0),
             23: Property(0, "Indiana Avenue", -1, (2,23), COLORS.RED, 220, 150, 18, 90, 250, 700, 875, 1050, 110),
@@ -52,7 +55,7 @@ class Board:
             39: Property(0, "Boardwalk", -1, (29,72), COLORS.BLUE, 400, 200, 50, 200, 600, 1400, 1700, 2000, 200),
         }
 
-    def update_location(self, player:Player, roll: int, update_history, new = None) -> None:
+    def update_location(self, player:Player, roll: int, new = None) -> None:
         """
         Update location with player\n
         @location: int\n
@@ -63,7 +66,7 @@ class Board:
             if new_location > 39:
                 new_location -= 40
                 player.receive(200)
-                update_history(f"Player {player.order} passed Go and received $200")
+            
             self.locations[player.location].players.remove(player.order)
             self.locations[new_location].players.append(player.order)
             player.location = new_location

--- a/monopoly.py
+++ b/monopoly.py
@@ -393,7 +393,8 @@ def player_roll(num_rolls):
                     if choice == 'f':
                         players[turn].pay_jail_fine()
                         update_history(f"{players[turn].name} paid $50 to leave jail.")
-                        break
+                        update_history(f"{players[turn].name} cannot roll after paying the fine.")
+                        return  # End the turn after paying the fine
                     elif choice == 'r':
                         update_history(f"{players[turn].name} will attempt to roll doubles.")
                         break
@@ -401,7 +402,7 @@ def player_roll(num_rolls):
                         update_history(f"Invalid choice. Please enter 'f' to pay fine or 'r' to roll.")
             else:
                 update_history(f"This is {players[turn].name}'s third turn in jail. They must attempt to roll doubles.")
-
+                
         input("\033[36;0HRoll dice?")
         dice = roll()
         bottom_screen_wipe()
@@ -415,6 +416,8 @@ def player_roll(num_rolls):
                 elif reason == "third_turn":
                     update_history(f"{players[turn].name} didn't roll doubles on their third turn. They paid $50 and left jail.")
                     players[turn].pay_jail_fine()
+                    update_history(f"{players[turn].name} cannot roll after paying the fine.")
+                    return  # End the turn after paying the fine on third turn
             else:
                 update_history(f"{players[turn].name} didn't roll doubles and is still in jail. Turns in jail: {players[turn].jail_turns}")
                 return

--- a/monopoly.py
+++ b/monopoly.py
@@ -383,29 +383,59 @@ def player_roll(num_rolls):
         player_color = COLORS.playerColors[turn]
         update_history(player_color + f"{players[turn].name}'s turn")
         print_commands()
+        
+        was_in_jail = players[turn].jail  # Flag to check if player was in jail before rolling
+        
+        if players[turn].jail:
+            if players[turn].jail_turns < 3:
+                while True:
+                    choice = input("\033[36;0HYou're in jail. Pay $50 fine (f) or attempt to roll doubles (r)?").lower().strip()
+                    if choice == 'f':
+                        players[turn].pay_jail_fine()
+                        update_history(f"{players[turn].name} paid $50 to leave jail.")
+                        break
+                    elif choice == 'r':
+                        update_history(f"{players[turn].name} will attempt to roll doubles.")
+                        break
+                    else:
+                        update_history(f"Invalid choice. Please enter 'f' to pay fine or 'r' to roll.")
+            else:
+                update_history(f"This is {players[turn].name}'s third turn in jail. They must attempt to roll doubles.")
+
         input("\033[36;0HRoll dice?")
         dice = roll()
         bottom_screen_wipe()
         update_history(f"Player {turn} rolled {dice[0]} and {dice[1]}")
 
-        if dice[0] == dice[1]:
-            if  num_rolls == 1:
+        if players[turn].jail:
+            left_jail, reason = players[turn].attempt_jail_roll(dice)
+            if left_jail:
+                if reason == "doubles":
+                    update_history(f"{players[turn].name} rolled doubles and got out of jail!")
+                elif reason == "third_turn":
+                    update_history(f"{players[turn].name} didn't roll doubles on their third turn. They paid $50 and left jail.")
+                    players[turn].pay_jail_fine()
+            else:
+                update_history(f"{players[turn].name} didn't roll doubles and is still in jail. Turns in jail: {players[turn].jail_turns}")
+                return
+
+        refresh_board()
+        board.update_location(players[turn], dice[0] + dice[1], update_history)
+        update_history(f"{players[turn].name} landed on {board.locations[players[turn].location].name}")
+        refresh_board()
+        
+        # Only check for doubles if the player wasn't in jail at the start of their turn
+        if dice[0] == dice[1] and not was_in_jail:
+            if num_rolls == 1:
                 update_history(f"{players[turn]} rolled doubles! Roll again.")
-            
             elif num_rolls == 2:
                 update_history(f"{players[turn]} rolled doubles!(X2) Roll again.")
-                
             elif num_rolls == 3:
-                update_history(f"Player {turn} rolled doubles three times\n in a row!")
+                update_history(f"Player {turn} rolled doubles three times in a row!")
                 update_history(f"Player {turn} is going to jail!")
-                players[turn].jail = True
-                board.update_location(players[turn], -1, update_history)
-        refresh_board()
-        #if player rolled their third double they will be in jail and their location doesn't update
-        if players[turn].jail == False:
-            board.update_location(players[turn], dice[0] + dice[1], update_history)
-            update_history(f"{players[turn].name} landed on {board.locations[players[turn].location].name}")
-            refresh_board()
+                players[turn].go_to_jail()
+                return
+
         if board.locations[players[turn].location].owner < 0:
             match board.locations[players[turn].location].owner:
                 case -1: #unowned
@@ -448,9 +478,10 @@ def player_roll(num_rolls):
             players[board.locations[cl].owner].receive(rent)
             update_history(f"{players[turn].name} paid ${rent} to {players[board.locations[cl].owner].name}")
         refresh_board()
-        #checks if player rolled a double, and has them roll again if they did.
-        if dice[0] == dice[1] and players[turn].jail == False:
-            num_rolls +=1
+        
+        # Check for doubles and roll again only if player wasn't in jail at the start of their turn
+        if dice[0] == dice[1] and not was_in_jail:
+            num_rolls += 1
             player_roll(num_rolls)
 
 while(True):

--- a/player_class.py
+++ b/player_class.py
@@ -11,6 +11,7 @@ class Player:
         self.jail = False
         self.jailcards = 0
         self.name = "Player #" + str(order + 1)
+        self.jail_turns = 0
     """
     Player cash\n
     @cash: int\n
@@ -56,17 +57,37 @@ class Player:
         @amount: int\n
         """
         self.cash += amount
-    def jail(self) -> None:
+    def go_to_jail(self) -> None:
         """
         Go to jail\n
         """
         self.location = 10
         self.jail = True
+        self.jail_turns = 0
     def leave_jail(self) -> None:
         """
         Leave jail\n
         """
         self.jail = False
-
+        self.jail_turns = 0
+    def attempt_jail_roll(self, dice: tuple) -> tuple:
+        """
+        Attempt to leave jail by rolling doubles
+        Returns (left_jail: bool, reason: str)
+        """
+        self.jail_turns += 1
+        if dice[0] == dice[1]:
+            self.leave_jail()
+            return True, "doubles"
+        elif self.jail_turns == 3:
+            self.pay_jail_fine()
+            return True, "third_turn"
+        return False, ""
+    def pay_jail_fine(self) -> None:
+        """
+        Pay jail fine of $50
+        """
+        self.pay(50)
+        self.leave_jail()
     def __str__(self) -> str:
         return f"Player {self.order}"


### PR DESCRIPTION
Added jail functionality to the game. Players that land in jail are given a choice to roll for doubles or pay a $50 fine to get out of jail. Players that roll doubles get out of jail and move that amount of spaces according to their roll. Players that do not roll doubles three times in a row while in jail are forced to pay the $50 fine. Players that pay the fine are also not able to move the turn they pay, voluntary or not. Changes were made in player_class.py in order to accommodate players being in a jailed state.