### PR TITLE
feat: Add debug flag to skip initialization

### DIFF
--- a/player.py
+++ b/player.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import socket
 from time import sleep
 import style as s
@@ -315,9 +316,10 @@ if __name__ == "__main__":
     get_graphics()
 
     # Feel free to comment out the 3 following lines for testing purposes.
-    # initialize()
-    # ss.make_fullscreen()
-    # ss.calibrate_screen('player')
+    if(len(sys.argv) == 1 or sys.argv[1] != "-debug"):
+        initialize()
+        ss.make_fullscreen()
+        ss.calibrate_screen('player')
 
     ss.clear_screen()
     ss.initialize_terminals()


### PR DESCRIPTION
Adds a new -debug command line argument to player.py that bypasses the 3 initialize commands. This prevents the need to comment out the functions and potential accidentals pushes of the comment.