### PR TITLE
fix: More Linux fixes

### DIFF
--- a/player.py
+++ b/player.py
@@ -52,14 +52,14 @@ def banker_check():
         )   
     elif(current_os == "Linux"):
         # We use a list of existing Linux terminals to run banker.
-        list_of_terms = [("gnome-terminal", "--"), ("kgx", "-x"), ("ptyxis", "--"),
+        list_of_terms = [("gnome-terminal", "-e"), ("kgx", "-x"), ("ptyxis", "--"),
                          ("konsole", "-e"), ("xfce4-terminal", "-e"), ("mate-terminal", "-e"),
                          ("tilix", "-e"), ("xterm", "-e")]
         
         launched = False
         for term in list_of_terms:
             try:
-                subprocess.Popen([term[0], term[1], "python banker.py"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                subprocess.Popen([term[0], term[1], "bash -c '" + sys.executable + " banker.py'"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.dirname(os.path.realpath(__file__)))
                 launched = True
                 break
             except FileNotFoundError:
@@ -71,7 +71,7 @@ def banker_check():
             if(term != "" and ' ' in term):
                 try:
                     term = term.split(" ")
-                    subprocess.Popen([term[0], term[1], "python banker.py"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    subprocess.Popen([term[0], term[1], "bash -c '" + sys.executable + " banker.py'"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.dirname(os.path.realpath(__file__)))
                 except:
                     print("Invalid command! Try running 'python banker.py' directly")
             else:

--- a/screenspace.py
+++ b/screenspace.py
@@ -460,7 +460,7 @@ def auto_calibrate_screen(mode: str = "player") -> None:
                 keyboard.release('ctrl')
                 time.sleep(0.1)
         elif os.name == 'posix': # Linux/macOS
-            print("\033[8;43;153t")
+            print("\033[8;50;160t")
     elif mode == "banker":
         if os.name == 'nt': # Windows
             while os.get_terminal_size().lines - 5 < 60 or os.get_terminal_size().columns - 5 < 200:

--- a/screenspace.py
+++ b/screenspace.py
@@ -460,13 +460,7 @@ def auto_calibrate_screen(mode: str = "player") -> None:
                 keyboard.release('ctrl')
                 time.sleep(0.1)
         elif os.name == 'posix': # Linux/macOS
-            while shutil.get_terminal_size().lines < HEIGHT or shutil.get_terminal_size().columns < WIDTH:
-                os.system("printf '\033[1;1t'")
-                time.sleep(0.1)
-
-            while shutil.get_terminal_size().lines > HEIGHT + 10 or shutil.get_terminal_size().columns > WIDTH + 10:
-                os.system("printf '\033[1;1t'")
-                time.sleep(0.1)
+            print("\033[8;43;153t")
     elif mode == "banker":
         if os.name == 'nt': # Windows
             while os.get_terminal_size().lines - 5 < 60 or os.get_terminal_size().columns - 5 < 200:
@@ -481,13 +475,7 @@ def auto_calibrate_screen(mode: str = "player") -> None:
                 keyboard.release('ctrl')
                 time.sleep(0.1)
         elif os.name == 'posix': # Linux/macOS
-            while shutil.get_terminal_size().lines < HEIGHT or shutil.get_terminal_size().columns < WIDTH:
-                os.system("printf '\033[1;1t'")
-                time.sleep(0.1)
-
-            while shutil.get_terminal_size().lines > HEIGHT + 10 or shutil.get_terminal_size().columns > WIDTH + 10:
-                os.system("printf '\033[1;1t'")
-                time.sleep(0.1)
+            print("\033[8;60;200t")
 
 def calibrate_screen(type: str) -> None:
     terminal_size = shutil.get_terminal_size()


### PR DESCRIPTION
Brings 2 Linux fixes:
* Checks what Python executable is running (Some distros use `python3` instead of `python`)
* Automatically resizes the terminal to accommodate the game contents (the user is still responsible for zooming in/out) 