### PR TITLE
Remove declaring bankruptcy by default, resolves issue #74

### DIFF
--- a/monopoly.py
+++ b/monopoly.py
@@ -18,7 +18,7 @@ gameboard = ""
 board = None
 history = []
 status = []
-CASH = 100
+CASH = 401
 num_players = 2
 bankrupts = 0
 players = []
@@ -412,13 +412,14 @@ def log_error(error_message: str) -> None:
         f.write(f"{formatted_datetime}\n{error_message}\n")
 
 def unittest():
-    #TODO
-    players[0].buy(1, board)
-    players[0].buy(3, board)
-    players[1].buy(5, board)
-    players[1].buy(15, board)
-    players[1].buy(25, board)
-    players[1].buy(35, board)
+    # TODO make a more robust unit testing system, using below as a framework. Allow the programmer to 
+    # choose which properties to buy for each player, and how much cash to allocate to each. 
+    # players[0].buy(1, board)
+    players[0].buy(31, board)
+    players[1].buy(32, board)
+    # players[1].buy(15, board)
+    # players[1].buy(25, board)
+    # players[1].buy(35, board)
     # players[3].buy(12, board)
     # players[3].buy(28, board)
 
@@ -725,10 +726,13 @@ def player_choice():
                     mortgage_logic(players[turn])
                 elif option == "s": # Sell houses/hotels
                     housing_logic(players[turn])
+                if players[turn].cash >= 0:
+                    break
                 option = input("\033[38;0Hb to declare bankruptcy, m to mortgage properties, s to sell houses/hotels").lower().strip()
-        update_history(f"{players[turn]} declared bankruptcy.")
-        players[turn].order = -1
-        bankrupts += 1
+        if players[turn].cash < 0:
+            update_history(f"{players[turn]} declared bankruptcy.")
+            players[turn].order = -1
+            bankrupts += 1
 
     # Wipe the bottom of the screen (input area)
     bottom_screen_wipe()
@@ -775,7 +779,7 @@ if __name__ == "__main__": # For debugging purposes. Can play standalone
     gameboard = g.get('gameboard')
     os.system('cls' if os.name == 'nt' else 'clear')
     
-    #unittest()
+    unittest()
     
     add_to_output(COLORS.WHITE + "\033[0;0H")
     add_to_output(gameboard)

--- a/monopoly.py
+++ b/monopoly.py
@@ -18,8 +18,8 @@ gameboard = ""
 board = None
 history = []
 status = []
-CASH = 2000
-num_players = 4
+CASH = 100
+num_players = 2
 bankrupts = 0
 players = []
 border = g.get('history and status')
@@ -719,21 +719,15 @@ def player_choice():
         update_history(f"{players[turn].name} ended their turn.")
     else:
         update_history(f"{players[turn]} is in debt. Resolve debts before ending turn.")
-        option = input("\033[38;0HResolve debts before ending turn.").lower().strip()
-        if(option == "b"): # Declare bankruptcy
-            update_history(f"{players[turn]} declared bankruptcy.")
-            players[turn].order = -1
-        elif(option == "m"): # Mortgage properties
-            mortgage_logic()
-        elif(option == "s"): # Sell houses/hotels
-            housing_logic()
-
-        # TODO! For now, just declare bankruptcy. Player should NOT, by default, be able to by pressing "enter"
-
-        else:
-            update_history(f"{players[turn].name} declared bankruptcy.")
-            players[turn].order = -1
-        # Need to fix all this sometime erghhghh
+        option = input("\033[38;0Hb to declare bankruptcy, m to mortgage properties, s to sell houses/hotels").lower().strip()
+        while option != 'b': # Loop until bankruptcy is declared
+                if option == "m": # Mortgage properties
+                    mortgage_logic(players[turn])
+                elif option == "s": # Sell houses/hotels
+                    housing_logic(players[turn])
+                option = input("\033[38;0Hb to declare bankruptcy, m to mortgage properties, s to sell houses/hotels").lower().strip()
+        update_history(f"{players[turn]} declared bankruptcy.")
+        players[turn].order = -1
         bankrupts += 1
 
     # Wipe the bottom of the screen (input area)


### PR DESCRIPTION
Added a while loop that checks if the player ever inputs the option "b", which is to declare bankruptcy, once the option is inputted, the while loop ends and bankruptcy is declared. Also made it to where the mortgage and selling functions are properly called since originally, there were no arguments provided when calling them.