### PR TITLE
Add docstrings to some functions that lacked a docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,6 @@ Ensure you have the following installed:
 - Player will take turns rolling dice, moving across the board, and choosing whether or not to buy a property.
 - Each play can see the gameboard in real time, and the banker will oversee the purchasing of property and rent payments
 
-# Game Commands
-Inputting these commands in the terminal will cause an action: 
-- roll: rolls two dice so the player can move
-- buy: purchases an unowned property when landing on it. 
-- deed <prop info>: will show you detailed property info such as rent and mortgage
-- properties: will list the properties that a player owns
-- mortgage: mortgages a property to raise money
-- pay: Pays an amount to another player or to the bank 
-- housing: Builds hotels or houses on properties where the player has a monopoly
-- Jail: Manages jail-related actions when a player is sent to jail
-
 # How the Game Works
 - Player Class: represents each player in the game and tracks player's cash, balance, owned properties, location, jail status. 
 - Board Class: Handles the game board, managing properties, whether a property is owned or mortgaged, and player locations. This class uses an internal dictionary to store information regarding price, rents, and whethere someone owns a property.

--- a/banker.py
+++ b/banker.py
@@ -255,7 +255,20 @@ def set_unittest() -> None:
         print("Skipping unit tests." if ss.VERBOSE else "")
         return
 
-def change_balance(id: int, delta: int):
+def change_balance(id: int, delta: int): 
+    """
+    Adjusts the balance of a specific player by a given amount.
+
+    This function updates the money attribute of the player identified by their ID.
+    A positive delta increases the player's balance, while a negative delta decreases it.
+
+    Args:
+        id (int): The unique identifier of the player whose balance needs to be adjusted.
+        delta (int): The amount to add or subtract from the player's balance.
+
+    Returns:
+        None
+    """
     clients[id].money += delta
 
 def handle_data(data: str, client: socket.socket) -> None:

--- a/casino.py
+++ b/casino.py
@@ -67,6 +67,17 @@ def module(socket: socket, active_terminal: Terminal, pid: int):
                 wrong = 1
 
 def get_submodules():
+    """
+    Retrieves a list of available casino game submodules.
+
+    This function scans the "casino_games" directory for Python files, dynamically 
+    imports each module, and checks if the module has a 'game_title' attribute.
+    If the attribute exists, the game's title along with its command name is added 
+    to the formatted list.
+
+    Returns:
+        str: A formatted string listing all available casino games with their commands.
+    """
     modules_list = ""
     for file in os.listdir("casino_games"):
         if file.endswith(".py"):

--- a/gamemanager.py
+++ b/gamemanager.py
@@ -39,20 +39,69 @@ def add_player_to_game(game_id: int, player) -> None:
     else: raise ValueError('Player already in game.')
 
 def remove_game(game_id: int) -> None:
+    """
+    Removes a game from the game manager by its ID.
+
+    This function searches for a game with the given ID in the list of active games
+    and removes it if found.
+
+    Args:
+        game_id (int): The unique identifier of the game to be removed.
+
+    Returns:
+        None
+    """
     games.pop(game_id) # intentional choice to keep all other game ids the same
 
 def is_game_full(game_id: int):
+    """
+    Checks whether a game has reached its maximum number of players.
+
+    This function retrieves a game by its ID and determines if the number of 
+    players has reached the game's defined limit.
+
+    Args:
+        game_id (int): The unique identifier of the game.
+
+    Returns:
+        bool: True if the game is full, False otherwise.
+    """
     if None in games[game_id].players:
         return False
     return len(games[game_id].players) >= games[game_id].MAXPLAYERS
 
 def game_exists(game_name: str) -> bool:
+    """
+    Checks if a game with the specified name exists in the game manager.
+
+    This function iterates through the list of active games and determines
+    if a game with the given name is currently available.
+
+    Args:
+        game_name (str): The name of the game to check.
+
+    Returns:
+        bool: True if the game exists, False otherwise.
+    """
     for game in games:
         if game.name == game_name:
             return True
     return False
 
 def player_in_game(game_name: str, player: str) -> bool:
+    """
+    Determines whether a specific player is currently in a game.
+
+    This function searches for a game with the given name and checks if the player 
+    is listed among its participants.
+
+    Args:
+        game_name (str): The name of the game.
+        player_name (str): The name of the player to check.
+
+    Returns:
+        bool: True if the player is in the specified game, False otherwise.
+    """
     for game in games:
         if game.name == game_name and player in [player.name for player in game.players]:
             return True
@@ -61,7 +110,6 @@ def player_in_game(game_name: str, player: str) -> bool:
 def get_game_by_id(game_id: int) -> Game:
     """
     Returns the game object with the given id.
-    Made into a function to support type hints.
     
     Parameters:
     game_id: int - The id of the game to return.

--- a/modules.py
+++ b/modules.py
@@ -14,6 +14,20 @@ calculator_history_queue = []
 calculator_history_current_capacity = 15
 
 def calculator(active_terminal: Terminal) -> str:
+    """
+    A command-line calculator module that supports basic arithmetic operations.
+
+    This function provides a terminal-based calculator where users can input mathematical
+    expressions, which are evaluated recursively. The results are displayed in the terminal,
+    and a history of recent calculations is maintained. Users can exit the calculator by
+    typing 'e'.
+
+    Args:
+        active_terminal (Terminal): The terminal interface where the calculator operates.
+
+    Returns:
+        str: The last computed result or an error message.
+    """
     # Helper function that contructs terminal printing.
     def calculator_terminal_response(footer_option: int) -> str:
         calculator_header = "\nCALCULATOR TERMINAL\nHistory:\n"
@@ -149,6 +163,21 @@ def list_properties() -> str:
     return ret_val
 
 def ttt_handler(server: Socket, active_terminal: Terminal, player_id: int) -> None:
+    """
+    Manages the client-side logic for joining and playing a Tic-Tac-Toe game.
+
+    This function interacts with the game server to check for ongoing Tic-Tac-Toe games,
+    allow the player to join or create a new game, and handle player moves using keyboard
+    input. The game board updates dynamically based on player actions.
+
+    Args:
+        server (Socket): The socket connection to the game server.
+        active_terminal (Terminal): The terminal where the game is displayed.
+        player_id (int): The player's unique identifier.
+
+    Returns:
+        None
+    """
     net.send_message(server, f'{player_id}ttt,getgamestate')
     time.sleep(0.1)
     active_terminal.update("Waiting for server...", padding=True)


### PR DESCRIPTION
Issue: Improve Documentation #107

Add docstrings to some functions that lacked a docstring. Included docstring to the following functions

Banker.py > def change_balance(id: int, delta: int) -> None:
Casino.py > def get_submodules() -> str:
GameManager.py  > def remove_game(game_id: int) -> None:
GameManager.py  > def game_is_full(game_id: int) -> bool:
GameManager.py  > def game_exists(game_name: str) -> bool:
GameManager.py  > def player_in_game(game_name: str, player_name: str) -> bool:
Modules.py > def calculator(active_terminal: Terminal) -> str:
Modules.py >  def list_properties() -> str:
Modules.py > def ttt_handler(server: Socket, active_terminal: Terminal, player_id: int) -> None:


Also Removed  the command section on the README.md as told to do so within the  issue Improve Documentation #107
