### PR TITLE
Fix unittest call compatibility between monopoly.py and banker.py

### DIFF
--- a/banker.py
+++ b/banker.py
@@ -523,7 +523,7 @@ def monopoly_controller(unit_test) -> None:
         None
     """
     add_to_output_area("Monopoly", "About to start Monopoly game.")
-    mply.unittest(unit_test)
+    mply.unittest(unit_test, num_players)
 
     if not play_monopoly:
         add_to_output_area("Monopoly", "No players in the game. Not attempting to run Monopoly.")
@@ -621,5 +621,11 @@ if __name__ == "__main__":
     choose_colorset("DEFAULT_COLORS")
     game = mply.start_game(STARTING_CASH, num_players, [clients[i].name for i in range(num_players)], clients)
     ss.print_banker_frames()
+
+    # TEMPORARY TEST HOOK FOR UNIT TEST FIX
+    if "-testfix" in sys.argv:
+        monopoly_controller(monopoly_unit_test)
+        sys.exit()
+
     threading.Thread(target=monopoly_controller, args=[monopoly_unit_test], daemon=True).start()
     start_receiver()

--- a/monopoly_directory/monopoly.py
+++ b/monopoly_directory/monopoly.py
@@ -403,10 +403,14 @@ def manage_properties(p:MonopolyPlayer):
             print("\033[38;0H" + ' ' * 70)
             print("\033[38;0HInvalid option!")
 
-def unittest(num:int = 5):
+def unittest(num:int = 5, num_players: int = 4):
     global CASH, players # TODO cash should be set by Banker.py and passed to here
-    if not num:
-        num = 4
+    board = Board(num_players)
+    players = []
+
+    for i in range(num_players):
+        players.append(MonopolyPlayer(1500, i, f"Player {i + 1}"))
+        
     if num == 1:
         # Two players, high cash
         CASH = 1500


### PR DESCRIPTION
Fixed issue #93 where previously unittestcase() did not care about the number of players, causing errors if there are less than 4 players in a game.