### PR TITLE
Bugfix/prevent end before roll

### DIFF
--- a/banker.py
+++ b/banker.py
@@ -578,6 +578,7 @@ def monopoly_game(client: Client = None, cmd: str = None) -> None:
             if ret_val.startswith("player_choice"):
                 ret_val.replace("player_choice", "")
                 client.can_roll = False
+                client.can_end_turn = True
             net.send_notif(client.socket, ret_val, "MPLY:")
         elif action == 'trybuy': #TODO Better handling of locations would be nice. 
             mply.buy_logic("banker", "b")
@@ -602,7 +603,7 @@ def monopoly_game(client: Client = None, cmd: str = None) -> None:
         elif action == 'continue':
             ret_val = mply.get_gameboard()
             net.send_notif(client.socket, ret_val, "MPLY:")
-        elif action == 'endturn':
+        elif action == 'endturn' and not client.can_roll:
             mply.end_turn()
             ret_val = "ENDOFTURN" + mply.get_gameboard()
             net.send_notif(client.socket, ret_val, "MPLY:")

--- a/banker.py
+++ b/banker.py
@@ -578,7 +578,6 @@ def monopoly_game(client: Client = None, cmd: str = None) -> None:
             if ret_val.startswith("player_choice"):
                 ret_val.replace("player_choice", "")
                 client.can_roll = False
-                client.can_end_turn = True
             net.send_notif(client.socket, ret_val, "MPLY:")
         elif action == 'trybuy': #TODO Better handling of locations would be nice. 
             mply.buy_logic("banker", "b")

--- a/monopoly_directory/monopoly.py
+++ b/monopoly_directory/monopoly.py
@@ -668,11 +668,12 @@ def evaluate_board_location(num_rolls: int, dice: tuple) -> str:
     """
     done_moving_around = False
     card = ""
+    output = "" #info/msgs to be shown to the user after the board position has been evaluated 
     while not done_moving_around:
         done_moving_around = True
         if board.locations[players[turn].location].owner < 0:
             if (board.locations[players[turn].location].owner == -1): #unowned
-                return get_gameboard() + set_cursor_str(0, 37) + "b to buy, enter to continue?"
+                output += set_cursor_str(0, 37) + "this property is unowned, b to buy"
             elif (board.locations[players[turn].location].owner == -2): #mortgaged
                 pass
             elif (board.locations[players[turn].location].owner == -3): #community chest
@@ -726,7 +727,7 @@ def evaluate_board_location(num_rolls: int, dice: tuple) -> str:
     if dice[0] == dice[1]: # and not was_in_jail:
         num_rolls += 1
         request_roll()
-    return "player_choice" + set_cursor_str(0, 36) + "e to end turn, p to manage properties, d to view a deed?" + get_gameboard()
+    return "player_choice" + output + set_cursor_str(0, 36) + "e to end turn, p to manage properties, d to view a deed?" + get_gameboard()
 
 def end_turn():
     global turn


### PR DESCRIPTION
Prevented player from ending turn if client.can_roll is true. Also changed evaluate_board_position in monopoly.py adding an additional output var so that it wont have to return without "player_choice" if a player lands on an unowned property.

Also rolling doubles is rly messed up rn