### PR TITLE
Fixed infinite money glitch logic and added debtok flag allowing debt

### DIFF
--- a/banker.py
+++ b/banker.py
@@ -59,6 +59,7 @@ num_players = 0
 play_monopoly = True
 monopoly_unit_test = 6 # assume 1 player, 2 owned properties. See monopoly.py unittest for more options
 messages = []
+DEBT_OK = False
 
 def add_to_output_area(output_type: str, text: str, color: str = COLORS.WHITE) -> None:
     """
@@ -376,7 +377,8 @@ def handle_data(data: str, client: socket.socket) -> None:
         handle_balance(data, client, mply, current_client.PlayerObject.cash, current_client.PlayerObject.properties)
 
     elif data.startswith('casino'):
-        handle_casino(data, client, change_balance, add_to_output_area, current_client.id, current_client.name)
+        handle_casino(data, client, change_balance, add_to_output_area, current_client.id, current_client.name, DEBT_OK)
+
     elif data.startswith('attack'):
         #run the attack similar to casino on client side and send game to player attacked, then send resulting command back
         handle_attack(data, current_client, client)
@@ -757,6 +759,9 @@ if __name__ == "__main__":
 
     if "-silent" in sys.argv:
         ss.VERBOSE = False
+
+    if "-debtok" in sys.argv:
+        DEBT_OK = True
 
     set_unittest() 
     # set_gamerules()

--- a/modules_directory/casino.py
+++ b/modules_directory/casino.py
@@ -5,6 +5,7 @@ from screenspace import Terminal
 import os
 import networking as net
 from socket import socket
+import sys
 
 name = "Casino Loader"
 command = "casino"
@@ -14,7 +15,7 @@ persistent = False # No need to run additional commands after switching
 # No out of focus function needed, because the terminal closes after use
 
 __modules = []
-def run(player_id: int, server: socket, active_terminal: Terminal):
+def run(player_id: int, server: socket, active_terminal: Terminal, debtok=False):
     """
     Casino Module
     Author: Jordan Brotherton (github.com/jordanbrotherton)
@@ -39,6 +40,8 @@ def run(player_id: int, server: socket, active_terminal: Terminal):
             ss.overwrite(c.RESET + c.RED + "\rInvalid input. Type in the name of the game followed by the wager. (ex. 'coin_flip 100')")
         elif(wrong == 3):
             ss.overwrite(c.RESET + c.RED + "\rWager has to be an integer greater than 0. Type in the name of the game followed by the wager. (ex. 'coin_flip 100')")
+        elif(wrong == 4):
+            ss.overwrite(c.RESET + c.RED + "\rYou do not have enough money for that wager.")
         
         game = input(f"\r").lower().split(" ")
         ss.overwrite(c.RESET+"\r" + " " * 40)
@@ -64,10 +67,14 @@ def run(player_id: int, server: socket, active_terminal: Terminal):
                 i = __import__('casino_games.' + game[0], fromlist=[''])
 
                 wager = int(game[1])
-                if(wager == 0): continue
+                if(wager == 0): continue                
 
                 net.send_message(server, f"{player_id}casino lose {wager}")
-                balance = int(net.receive_message(server))
+                new_balance = int(net.receive_message(server))
+                if new_balance == balance:
+                    wrong = 4
+                    continue
+                balance = new_balance
                 ss.overwrite(c.RESET+"\r" + " " * 40)
                 active_terminal.busy(server, player_id)
                 winnings = i.play(active_terminal,wager)
@@ -101,7 +108,7 @@ def get_submodules():
 
 get_submodules() # Load the casino games when the module is imported (at start of game)
 
-def handle(cmds: str, client_socket, change_balance, add_to_output_area, id, name) -> None:
+def handle(cmds: str, client_socket, change_balance, add_to_output_area, id, name, debtok=False) -> None:
     """
     Handles casino-related commands for a client by updating their balance.
 
@@ -115,6 +122,7 @@ def handle(cmds: str, client_socket, change_balance, add_to_output_area, id, nam
         add_to_output_area (function): Function to add messages to the output area.
         id (int): The ID of the client whose balance is being updated.
         name (str): The name of the client whose balance is being updated.
+        debtok (bool): If True, allows the client to go into debt.
 
     Returns:
         None
@@ -126,10 +134,18 @@ def handle(cmds: str, client_socket, change_balance, add_to_output_area, id, nam
     command_data = cmds.split(' ')
     delta = 1 if command_data[1] == 'win' else -1
     amount = int(command_data[2])
+    
+    current_balance = change_balance(id, 0)
+
+    if delta == -1 and not debtok and amount > current_balance:
+        add_to_output_area("Casino",
+            f"Denied wager of ${amount} for {name} (balance ${current_balance})")
+        net.send_message(client_socket, str(current_balance))
+        return
+    
     money = change_balance(id, delta * amount)
     add_to_output_area("Casino", f"Updated {name}'s balance by {delta * amount}. New balance: {money}")
     net.send_message(client_socket, str(money))
-
 
 if __name__ == "__main__":
     run(1)


### PR DESCRIPTION
This PR is to resolve the issue regarding the infinite money glitch in the casino of TERMINALMONOPOLY.

This PR adds logic to handle wagering more than you have in the casino option. Furthermore, it adds a flag the banker can set if they are ok with the players going into possible debt.