### PR TITLE
Fix ValueError in help command input (fixes #184)

### DIFF
--- a/modules_directory/help.py
+++ b/modules_directory/help.py
@@ -33,11 +33,11 @@ def run(player_id:int, server: socket, active_terminal: Terminal, param):
         if(len(pages) > 1):    
             overwrite(c.RESET + c.YELLOW + f"\rModule has {len(pages)} help pages available. Type `help <module> <page #>` for more information.")
         if(len(param) == 2):    # if page_num is provided
-            page_num = int(param[1])
             if not(param[1].isdigit()):
                 overwrite(c.RESET + c.RED + "\rInvalid parameter. Type `help <module> <page #>` for more information.")
                 return
-            elif(page_num < 1 or page_num > len(pages)):
+            page_num = int(param[1])
+            if(page_num < 1 or page_num > len(pages)):
                 overwrite(c.RESET + c.RED + f"\r{module.upper()} help does not have page {int(param[1])}! Please select another page number.")
                 return
             else:


### PR DESCRIPTION
fixes #184

The help command crashed with a ValueError when users entered a non-integer as the page parameter (ex: "help casino slots").

The issue was that "int(param[1])" was called before validating that the input was a digit. Moved the ".isdigit()" check before the integer conversion to prevent the crash. (Also changed "elif" to "if" on the range check since it no longer directly follows the validation block.)
